### PR TITLE
add --extras-require option

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -11,7 +11,8 @@ from .utils import comment, dedup, format_requirement, key_from_req, UNSAFE_PACK
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
                  emit_trusted_host, annotate, generate_hashes,
-                 default_index_url, index_urls, trusted_hosts, format_control):
+                 default_index_url, index_urls, trusted_hosts, format_control,
+                 extras_require):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
@@ -24,6 +25,7 @@ class OutputWriter(object):
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
+        self.extras_require = extras_require
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -47,6 +49,8 @@ class OutputWriter(object):
                     params += ['--no-annotate']
                 if self.generate_hashes:
                     params += ["--generate-hashes"]
+                for extra in self.extras_require:
+                    params += ["--extras-require {}".format(extra)]
                 params += ['--output-file', self.dst_file]
                 params += self.src_files
                 yield comment('#    pip-compile {}'.format(' '.join(params)))


### PR DESCRIPTION
`setup.py`:
```
from setuptools import find_packages, setup


setup(
    name="test",
    version="0.1.0",
    install_requires=['obscure'],
    extras_require={
        'test': ['mock']
    }
)
```

```
$ pip-compile -ex test -o requirements.dev.txt setup.py
```

```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --extras-require test --output-file requirements.dev.txt setup.py
#

funcsigs==1.0.2           # via mock
mock==2.0.0
obscure==1.0.1
pbr==3.1.1                # via mock
six==1.11.0               # via mock
```